### PR TITLE
Fix compile error on backtrace acquisition

### DIFF
--- a/tricore-windows/src/defmt.rs
+++ b/tricore-windows/src/defmt.rs
@@ -1,3 +1,4 @@
+use crate::backtrace::StacktraceExt;
 use anyhow::{bail, Context};
 use byteorder::ReadBytesExt;
 use rust_mcd::{
@@ -7,8 +8,6 @@ use rust_mcd::{
 };
 use std::io::Write;
 use tricore_common::backtrace::Stacktrace;
-
-use crate::backtrace::StacktraceExt;
 
 /// Decode the rtt data from the first channel of the specified rtt block and
 /// write it to the supplied data sink.
@@ -131,7 +130,8 @@ pub fn decode_rtt<W: Write>(
             let core_state = core.query_state()?;
             if core_state.state != CoreState::Running {
                 log::trace!("Device halted, attempting to acquire backtrace");
-                let backtrace = Stacktrace::read_current(core)
+                let backtrace = (&*core)
+                    .read_current()
                     .with_context(|| "Cannot read backtrace from device")?;
                 return Ok(HaltReason::DebugHit(backtrace));
             }


### PR DESCRIPTION
Following https://github.com/veecle/tricore-probe/blob/main/tricore-docker/README.md I got a compiler error, due to a missing method. I guess this is the fix. It compiles, now I'm going to test it.