### PR TITLE
Refactor trap decoding and improve log output

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-02-01"
+channel = "nightly-2023-09-20"

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -245,7 +245,7 @@ impl TrapMetadata {
 
     /// Based on the metadata in this structure, attempt to identify the trap
     /// class based on the given address
-    /// 
+    ///
     /// This address is usually the program counter of the program when it hit the trap.
     fn trap_class(&self, address: u32) -> Option<u8> {
         let offset_from_start = address.checked_sub(self.trap_symbol?)?;

--- a/src/chip_interface.rs
+++ b/src/chip_interface.rs
@@ -11,7 +11,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(feature = "windows")] {
         use tricore_windows as imp;
     } else {
-        compile_error!("Features 'docker' and 'windows' are mutually exclusive")
+        compile_error!("Features 'docker' and 'windows' are mutually exclusive");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,15 +34,9 @@ struct Args {
     #[arg(long, default_value_t = false)]
     halt_memtool: bool,
 
-    /// Enable verbose logging
-    #[arg(short, long)]
-    verbose: bool,
-}
-
-fn existing_path(input_path: &str) -> Result<PathBuf, anyhow::Error> {
-    let path = PathBuf::from_str(input_path).with_context(|| "Value is not a correct path")?;
-
-    Ok(path)
+    /// Increase verbosity for logging
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -50,9 +44,7 @@ fn main() -> anyhow::Result<()> {
 
     env_logger::init();
 
-    if !args.verbose {
-        log::set_max_level(log::LevelFilter::Info);
-    }
+    log::set_max_level(filter_from_verbosity(args.verbose));
 
     let command_server = ChipInterface::new(args.backend)?;
 
@@ -75,4 +67,19 @@ fn main() -> anyhow::Result<()> {
     backtrace_info.log_stdout();
 
     Ok(()) as Result<(), anyhow::Error>
+}
+
+fn filter_from_verbosity(verbose_flag_count: u8) -> log::LevelFilter {
+    match verbose_flag_count {
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    }
+}
+
+fn existing_path(input_path: &str) -> Result<PathBuf, anyhow::Error> {
+    let path = PathBuf::from_str(input_path).with_context(|| "Value is not a correct path")?;
+
+    Ok(path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ struct Args {
 
     /// Sets the log level
     #[arg(short, long, value_enum, required = false, default_value_t = LogLevel::Warn)]
-    log: LogLevel,
+    log_level: LogLevel,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -45,7 +45,7 @@ fn main() -> anyhow::Result<()> {
 
     env_logger::init();
 
-    let log_filter = match args.log {
+    let log_filter = match args.log_level {
         LogLevel::Warn => LevelFilter::Warn,
         LogLevel::Info => LevelFilter::Info,
         LogLevel::Debug => LevelFilter::Debug,

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,6 @@ fn filter_from_verbosity(verbose_flag_count: u8) -> log::LevelFilter {
     }
 }
 
-fn existing_path(input_path: &str) -> Result<PathBuf, anyhow::Error> {
-    let path = PathBuf::from_str(input_path).with_context(|| "Value is not a correct path")?;
-
-    Ok(path)
+fn existing_path(input_path: &str) -> anyhow::Result<PathBuf> {
+    PathBuf::from_str(input_path).with_context(|| "Value is not a correct path")
 }

--- a/tricore-common/src/backtrace/csa.rs
+++ b/tricore-common/src/backtrace/csa.rs
@@ -1,10 +1,10 @@
 //! This module defines structure for CSA's.
-//! 
+//!
 //! See also https://www.infineon.com/dgdl/tc1_6__architecture_vol1.pdf?fileId=db3a3043372d5cc801373b0f374d5d67#G8.6699641
 use super::pcxi::PCXI;
 
 /// A link word that points to a CSA
-/// 
+///
 /// See https://www.infineon.com/dgdl/tc1_6__architecture_vol1.pdf?fileId=db3a3043372d5cc801373b0f374d5d67#G8.6699687
 #[derive(Debug, Clone, Copy)]
 pub struct ContextLinkWord {
@@ -30,7 +30,7 @@ pub enum SavedContext {
 
 impl SavedContext {
     /// The [PCXI] register value stored in this context
-    /// 
+    ///
     /// This function is available on the type itself since both the upper context as well
     /// as the lower context hold a stored pcxi register
     pub fn pcxi(&self) -> PCXI {
@@ -41,7 +41,7 @@ impl SavedContext {
     }
 
     /// The return address stored in this context
-    /// 
+    ///
     /// Useful for providing additional information like the source address
     pub fn return_address(&self) -> u32 {
         match self {

--- a/tricore-docker/rpc-api/src/win_daemon/mod.rs
+++ b/tricore-docker/rpc-api/src/win_daemon/mod.rs
@@ -36,7 +36,6 @@ pub enum Response {
     StackFrame(Stacktrace),
 }
 
-
 pub enum Error {
     Internal,
 }

--- a/tricore-docker/src/daemon.rs
+++ b/tricore-docker/src/daemon.rs
@@ -4,7 +4,8 @@ use crate::builder::DockerBuilder;
 
 use super::{
     builder::{DockerInstance, Spawned},
-    logger, pipe::{DuplexPipeConnection, Pipe},
+    logger,
+    pipe::{DuplexPipeConnection, Pipe},
 };
 
 pub struct VirtualizedDaemon {

--- a/tricore-docker/src/ftdi.rs
+++ b/tricore-docker/src/ftdi.rs
@@ -23,7 +23,9 @@ impl FTDIClient {
             handle_client(input, output);
         });
 
-        FTDIClient { _ftdi_thread: ftdi_thread }
+        FTDIClient {
+            _ftdi_thread: ftdi_thread,
+        }
     }
 
     #[allow(dead_code)]
@@ -313,7 +315,6 @@ fn handle_client(input: &File, output: &File) {
     }
     log::warn!("Failed to read from input");
 }
-
 
 pub struct LocalState {
     devices: HashMap<u32, FT_HANDLE>,

--- a/tricore-docker/src/lib.rs
+++ b/tricore-docker/src/lib.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use rpc_api::win_daemon::{Commands, Response, WriteHex};
 use tricore_common::{backtrace::Stacktrace, Chip};
 
-use self::{daemon::VirtualizedDaemon, pipe::DuplexPipeConnection, ftdi::FTDIClient};
+use self::{daemon::VirtualizedDaemon, ftdi::FTDIClient, pipe::DuplexPipeConnection};
 
 pub type Config = DockerConfig;
 
@@ -110,7 +110,7 @@ impl ChipInterface {
     fn next_response(&self) -> anyhow::Result<Response> {
         let r = ciborium::de::from_reader(self.server.from().open())
             .with_context(|| "Failed to obtain response from docker")?;
-        
+
         Ok(r)
     }
 }

--- a/tricore-windows/src/backtrace/mod.rs
+++ b/tricore-windows/src/backtrace/mod.rs
@@ -12,7 +12,7 @@ mod pcxi;
 /// Extension trait to obtain a stacktrace
 pub trait StacktraceExt: Sized {
     /// Read the stacktrace for the given core
-    /// 
+    ///
     /// This function is available on the [Core] type.
     fn read_current(&self) -> anyhow::Result<Stacktrace>;
 }

--- a/tricore-windows/src/backtrace/pcxi.rs
+++ b/tricore-windows/src/backtrace/pcxi.rs
@@ -4,7 +4,7 @@ use tricore_common::backtrace::{csa::SavedContext, pcxi::PCXI};
 use crate::backtrace::csa::ContextLinkWordExt;
 
 /// Extension trait to iterate over the CSA link chain
-/// 
+///
 /// Most notably implemented for [PCXI]
 pub trait PCXIExt {
     /// Allows to iterate over all contexts using the specified core access
@@ -35,7 +35,7 @@ impl<'a> Iterator for ContextWalker<'a> {
                 Some(ctx)
             }
             Err(err) => {
-                // We are bound to the Iterator trait so we cannot return an 
+                // We are bound to the Iterator trait so we cannot return an
                 // error here
                 log::error!(
                     "Failed to obtain full list of context from device: {:?}",

--- a/tricore-windows/src/das.rs
+++ b/tricore-windows/src/das.rs
@@ -15,7 +15,7 @@ pub fn run_console() {
     let _started_dashpas = process.spawn().unwrap();
 
     log::trace!("Starting UDAS_Console");
-    
+
     let mut udas_console = Command::new(das_home.join("servers/udas/UDAS_Console.exe"));
     let udas_console = udas_console.stderr(Stdio::inherit()).stdout(Stdio::null());
     let mut udas_console = udas_console.spawn().unwrap();

--- a/tricore-windows/src/lib.rs
+++ b/tricore-windows/src/lib.rs
@@ -2,16 +2,16 @@
 
 use std::io::Write;
 
+use das::run_console;
 use defmt::{decode_rtt, HaltReason};
 use flash::MemtoolUpload;
 use rust_mcd::{reset::ResetClass, system::System};
-use das::run_console;
 use tricore_common::{backtrace::Stacktrace, Chip};
 
 mod backtrace;
+pub mod das;
 pub mod defmt;
 pub mod flash;
-pub mod das;
 
 #[derive(clap::Args, Debug)]
 pub struct Config;


### PR DESCRIPTION
With this, it is still wonky how we decode trap metadata - we should actually obtain the currently installed trap table from the device instead of scanning an elf file.

However now the call stack can still be backtracked even if the trap information is missing or incorrect.