### PR TITLE
Update readme prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ during installation.
 4. `objcopy` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
 5. `addr2line` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
 6. Rust nightly toolchain
+7. [LLVM](https://github.com/llvm/llvm-project/releases) (also set `LIBCLANG_PATH` to `<your-path>\LLVM\lib`)
 
 # Known flaws
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ When installing this program make sure the environment variable `MEMTOOL_PATH` i
 to the root of the memtool installation. If the environment variable is not set 
 a default path is assumed that should work if the install path was not changed 
 during installation.
-3. [`defmt-print` CLI utility](https://crates.io/crates/defmt-print)
-4. `objcopy` CLI utility
-5. `addr2line` CLI utility
-6. Rust nightly toolchain
 
-You can obtain the last two applications e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) 
-project.
+3. [`defmt-print` CLI utility](https://crates.io/crates/defmt-print)
+4. `objcopy` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
+5. `addr2line` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
+6. Rust nightly toolchain
 
 # Known flaws
 


### PR DESCRIPTION
Fixed some issues related to the prerequisite list in readme:

- there was a missing newline which broke the formatting of the numbered list
- there was some inconsistency regarding this sentence: "You can obtain the last two applications e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project." because you mean here `objcopy` and `addr2line` but those were not the last 2 elements in the list
- added LLVM to the list because without it (more specifically without `libclang.dll`) I encountered this error:

```
C:\Users\andra\git-repos\tricore-probe>cargo build
...
   Compiling rust-mcd v0.1.0 (C:\Users\andra\git-repos\tricore-probe\rust-mcd)
error: failed to run custom build command for `rust-mcd v0.1.0 (C:\Users\andra\git-repos\tricore-probe\rust-mcd)`

Caused by:
  process didn't exit successfully: `C:\Users\andra\git-repos\tricore-probe\target\debug\build\rust-mcd-44d1f68bb99c93f6\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-changed=mcd_demo_basic_120412/src/mcd_api.h
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64-pc-windows-msvc
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_msvc
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:rerun-if-changed=mcd_demo_basic_120412/src/mcd_api.h

  --- stderr
  thread 'main' panicked at C:\Users\andra\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bindgen-0.69.4\lib.rs:622:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['clang.dll', 'libclang.dll'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Installing LLVM and setting env var `LIBCLANG_PATH` solves the issue:

```
C:\Users\andra\git-repos\tricore-probe>cargo build
   Compiling bindgen v0.69.4
   Compiling rust-mcd v0.1.0 (C:\Users\andra\git-repos\tricore-probe\rust-mcd)
   Compiling tricore-windows v0.1.0 (C:\Users\andra\git-repos\tricore-probe\tricore-windows)
   Compiling tricore-probe v0.1.0 (C:\Users\andra\git-repos\tricore-probe)
    Finished dev [unoptimized + debuginfo] target(s) in 9.47s
```