### PR TITLE
Fix memtool instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ work properly:
 2. [Infineon Memtool 2021.08](https://www.infineon.com/cms/en/tools/aurix-tools/free-tools/infineon/): 
 
 When installing this program make sure the environment variable `MEMTOOL_PATH` is set
-to the root of the memtool installation. If the environment variable is not set 
+to the memtool executable (`<your-path>\Infineon\Memtool 2021\IMTMemtool.exe`). If the environment variable is not set 
 a default path is assumed that should work if the install path was not changed 
 during installation.
 


### PR DESCRIPTION
The readme states that you have to set `MEMTOOL_PATH` to the root of the memtool installation but it is incorrect. If you do that you will face this error:

```
PS C:\Users\andra\git-repos\tricore-probe> gci env:* | sort-object name

Name                           Value
----                           -----
...
MEMTOOL_PATH                   C:\Apps\Infineon\Memtool 2021
...
PS C:\Users\andra\git-repos\tricore-probe> cargo run -- .\blinking_led_1_litekit.elf -l trace
   Compiling tricore-windows v0.1.0 (C:\Users\andra\git-repos\tricore-probe\tricore-windows)
   Compiling tricore-probe v0.1.0 (C:\Users\andra\git-repos\tricore-probe)
    Finished dev [unoptimized + debuginfo] target(s) in 1.54s
     Running `target\debug\tricore-probe.exe .\blinking_led_1_litekit.elf -l trace`
[2024-04-22T12:24:18Z TRACE tricore_windows::das] Starting dashpas
[2024-04-22T12:24:18Z TRACE tricore_windows::das] Starting UDAS_Console
[2024-04-22T12:24:18Z INFO  tricore_windows::das] DAS server started
[2024-04-22T12:24:19Z DEBUG rust_mcd::library] Initializing MCD library
[2024-04-22T12:24:19Z DEBUG tricore_probe::chip_interface] Connecting to any available device
[2024-04-22T12:24:19Z INFO  tricore_probe::chip_interface] Converting elf .\blinking_led_1_litekit.elf to hex file
[2024-04-22T12:24:19Z INFO  tricore_probe::chip_interface] Flashing hex file
[2024-04-22T12:24:19Z TRACE rust_mcd::connection] Scanned for servers, found Connection { servers: [ServerInfo { acc_hw: "DAS JDS AURIX LITE KIT V2.0 (TC375) LK7KFCF1", server: "UDAS", system_instance: "" }] }
Error: Cannot flash elf file

Caused by:
    0: Failed to run memtool
    1: Could not start memtool to flash device
    2: Access is denied. (os error 5)
error: process didn't exit successfully: `target\debug\tricore-probe.exe .\blinking_led_1_litekit.elf -l trace` (exit code: 1)
```

It should point to the memtool .exe instead:

```
PS C:\Users\andra\git-repos\tricore-probe> gci env:* | sort-object name

Name                           Value
----                           -----
...
MEMTOOL_PATH                   C:\Apps\Infineon\Memtool 2021\IMTMemtool.exe
...
PS C:\Users\andra\git-repos\tricore-probe> cargo run -- .\blinking_led_1_litekit.elf -l trace
   Compiling tricore-windows v0.1.0 (C:\Users\andra\git-repos\tricore-probe\tricore-windows)
   Compiling tricore-probe v0.1.0 (C:\Users\andra\git-repos\tricore-probe)
    Finished dev [unoptimized + debuginfo] target(s) in 1.35s
     Running `target\debug\tricore-probe.exe .\blinking_led_1_litekit.elf -l trace`
[2024-04-22T12:25:03Z TRACE tricore_windows::das] Starting dashpas
[2024-04-22T12:25:03Z TRACE tricore_windows::das] Starting UDAS_Console
[2024-04-22T12:25:03Z INFO  tricore_windows::das] DAS server started
[2024-04-22T12:25:04Z DEBUG rust_mcd::library] Initializing MCD library
[2024-04-22T12:25:04Z DEBUG tricore_probe::chip_interface] Connecting to any available device
[2024-04-22T12:25:04Z INFO  tricore_probe::chip_interface] Converting elf .\blinking_led_1_litekit.elf to hex file
[2024-04-22T12:25:04Z INFO  tricore_probe::chip_interface] Flashing hex file
[2024-04-22T12:25:04Z TRACE rust_mcd::connection] Scanned for servers, found Connection { servers: [ServerInfo { acc_hw: "DAS JDS AURIX LITE KIT V2.0 (TC375) LK7KFCF1", server: "UDAS", system_instance: "" }] }
[2024-04-22T12:25:04Z INFO  tricore_windows::flash] Spawned Infineon Memtool to flash hex file
[2024-04-22T12:25:07Z INFO  tricore_windows::flash] Infineon Memtool terminated successfully
```