### PR TITLE
Add more info to readme (about runner and quickstart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ on the [`defmt`](https://defmt.ferrous-systems.com/) framework to integrate seem
 This program can be configured as a [runner](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner). 
 Check [`main.rs`](src/main.rs) for additional configuration options.
 
+A simple runner config for a TC375 lite kit could look like this:
+
+```toml
+[target.tc162-htc-none]
+runner = "tricore-probe"
+# Default dwarf version of v0.2.0 HighTec compiler is version 2 which is
+# incompatible with defmt location information
+rustflags = ["-Z", "dwarf-version=4"]
+
+[build]
+target = "tc162-htc-none"
+```
+
+Then you can call `cargo run` in your project root which will run the built .elf on your board via `tricore-probe`.
+
 # Requirements
 
 This program has various dependencies that must be installed for this program to 
@@ -25,6 +40,29 @@ during installation.
 5. `addr2line` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
 6. Rust nightly toolchain
 7. [LLVM](https://github.com/llvm/llvm-project/releases) (also set `LIBCLANG_PATH` to `<your-path>\LLVM\lib`)
+
+# Quickstart
+
+```
+> git clone https://github.com/veecle/tricore-probe.git
+> cd tricore-probe
+> cargo build
+> .\target\debug\tricore-probe.exe <your-executable>.elf --list-devices
+Found 1 devices:
+Device 0: "DAS JDS AURIX LITE KIT V2.0 (TC375) LK7KFCF1"
+```
+
+In case of a simple example based on the [Bluewind blinky](https://github.com/bluewind-embedded-systems/bw-r-drivers-tc37x-examples/tree/main/blinky) the output will look something like this:
+
+```
+> .\target\debug\tricore-probe.exe blinky.elf
+DEBUG power on reset
+└─ bw_r_drivers_tc37x::ssw::tc0::init_clock @ C:\Users\andra\.cargo\registry\src\github.com-d2f9efa20490c5c8\bw-r-drivers-tc37x-0.2.0\src\ssw\tc0.rs:12
+INFO  LED2 toggle
+└─ blinky::main @ src\main.rs:46
+```
+
+For more sample code refer to the Bluewind [bare-metal examples](https://github.com/bluewind-embedded-systems/bw-r-drivers-tc37x-examples) and to the Veecle [PXROS examples](https://github.com/veecle/veecle-pxros/tree/main/examples).
 
 # Known flaws
 


### PR DESCRIPTION
I have extended the readme a bit so newcomers will have an easier time starting with `tricore-probe`.