### PR TITLE
Update dependencies & Rust 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-09-20
+          toolchain: 1.74.0
           targets: x86_64-pc-windows-msvc
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-09-20
+          toolchain: 1.74.0
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Tricore-probe: Run Rust effortlessly on Infineon AURIX™ TriCore
 
 [dependencies]
 anyhow = "1.0.69"
-bitfield-struct = "0.3.2"
+bitfield-struct = "0.6.1"
 byteorder = "1.5.0"
 clap = { version = "4.1.4", features = ["derive"] }
 colored = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Tricore-probe: Run Rust effortlessly on Infineon AURIX™ TriCore™ chips."
+rust-version = "1.74.0"
 
 [dependencies]
 anyhow = "1.0.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.1.4", features = ["derive"] }
 colored = "2.0.0"
 log = "0.4.17"
 tempfile = "3.3.0"
-env_logger = "0.10.0"
+env_logger = "0.11.3"
 elf = "0.7.1"
 
 rust-mcd = { path = "rust-mcd" }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ a default path is assumed.
 3. [`defmt-print` CLI utility](https://crates.io/crates/defmt-print)
 4. `objcopy` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
 5. `addr2line` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
-6. Rust nightly toolchain
+6. Rust toolchain
 7. [LLVM](https://github.com/llvm/llvm-project/releases) (also set `LIBCLANG_PATH` to `<your-path>\LLVM\lib`)
 
 # Known flaws

--- a/rust-mcd/Cargo.toml
+++ b/rust-mcd/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-libloading = "0.7.4"
+libloading = "0.8.3"
 lazy_static = "1.4.0"
 byteorder = "1.4.3"
 log = "0.4.17"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2023-09-20" # Keep this in sync with the docker file

--- a/src/backtrace/pcxi.rs
+++ b/src/backtrace/pcxi.rs
@@ -5,7 +5,6 @@ use super::csa::{ContextLinkWord, SavedContext};
 
 /// Models the PCXI register of the tricore architecture.
 #[bitfield(u32)]
-#[derive(Default)]
 pub struct PCXI {
     pub previous_context_pointer: u16,
     #[bits(4)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ fn existing_path(input_path: &str) -> anyhow::Result<PathBuf> {
     PathBuf::from_str(input_path).with_context(|| "Value is not a correct path")
 }
 
-fn pretty_print_devices(devices: &Vec<DeviceSelection>) {
+fn pretty_print_devices(devices: &[DeviceSelection]) {
     if devices.is_empty() {
         println!("No devices available");
         return;

--- a/tricore-docker/build_artifacts.sh
+++ b/tricore-docker/build_artifacts.sh
@@ -11,7 +11,7 @@ docker run \
     --env DAS_HOME="C:\\DAS64" \
     --env AURIX_FLASHER_PATH="C:\\Infineon\\AURIXFlasherSoftwareTool\\AURIXFlasher.exe" \
     veecle/xwin \
-    cargo build -p tricore-probe -Z build-std --target x86_64-pc-windows-msvc --target-dir tricore-docker/docker-build-exe --features in_docker
+    cargo build -p tricore-probe --target x86_64-pc-windows-msvc --target-dir tricore-docker/docker-build-exe --features in_docker
 
 
 docker run \
@@ -23,7 +23,7 @@ docker run \
     --env DAS_HOME="C:\\DAS64" \
     --env AURIX_FLASHER_PATH="C:\\Infineon\\AURIXFlasherSoftwareTool\\AURIXFlasher.exe" \
     veecle/xwin \
-    cargo +nightly-2023-09-20 install defmt-print -Z build-std --target x86_64-pc-windows-msvc --root docker-build-exe --target-dir docker-build-exe --locked
+    cargo install defmt-print --target x86_64-pc-windows-msvc --root docker-build-exe --target-dir docker-build-exe --locked
 
 docker run \
     --rm \
@@ -34,7 +34,7 @@ docker run \
     --env DAS_HOME="C:\\DAS64" \
     --env AURIX_FLASHER_PATH="C:\\Infineon\\AURIXFlasherSoftwareTool\\AURIXFlasher.exe" \
     veecle/xwin \
-    cargo +nightly-2023-09-20 install addr2line -Z build-std --target x86_64-pc-windows-msvc --root docker-build-exe --features bin  --git https://github.com/gimli-rs/addr2line --target-dir docker-build-exe --locked
+    cargo install addr2line --target x86_64-pc-windows-msvc --root docker-build-exe --features bin  --git https://github.com/gimli-rs/addr2line --target-dir docker-build-exe --locked
 
 
 # Copy artifacts so we don't have to pass the whole build folder in the build context


### PR DESCRIPTION
We don't actually need nightly, so this PR drops the nightly requirement. It also updates all dependencies.

Based on https://github.com/veecle/tricore-probe/pull/25, which needs to be merged first.