### PR TITLE
Docs: extend defmt-cli install info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently only Windows and Linux are supported.
     Please make sure the `DAS_HOME` environment variable points to the DAS tool installation directory.
 2. [Infineon AURIX™ Flasher Software Tool](https://softwaretools.infineon.com/tools/com.ifx.tb.tool.aurixflashersoftwaretool)
    Please make sure the `AURIX_FLASHER_PATH` environment variable points to the AurixFlasher executable (`<your-path>\AURIXFlasher.exe`).
-3. [`defmt-print` CLI utility](https://crates.io/crates/defmt-print)
+3. [`defmt-print` CLI utility](https://crates.io/crates/defmt-print): `cargo install defmt-print`
 4. `objcopy` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
 5. `addr2line` CLI utility (obtain e.g. as part of the [MinGW-w64](https://www.mingw-w64.org/) project)
 6. Rust toolchain


### PR DESCRIPTION
## Intent

At HighTec we noticed that for newcomers it is not obvious how to install the `defmt-print` executable. The readme is confusing currently because it points them to the defmt-print crate and there they see these:

> Run the following Cargo command in your project directory:
> `cargo add defmt-print`

> Or add the following line to your Cargo.toml:
> `defmt-print = "0.3.12"`

But instead they would need this: `cargo install defmt-print` so this change spells it out for them.

## Checklist
- [x] Documentation in README, crate, module, function and/or other locations added/adapted.
- [ ] New tests added and/or existing tests adapted.
- [x] PR is limited to a single logical change.
- [x] At least the first commit has a clear title and a descriptive message containing reasoning for the change. This will be included in the final commit message after squashing and merging.