### PR TITLE
feat: Added support for single-core applications and optional elf file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tricore-probe"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker build . --tag veecle/flash-tricore --build-arg=AGREE_INFINEON_TERMS=1 -f 
 
 Install `tricore-probe`:
 ```shell
-cargo install --path .
+cargo install tricore-probe --git https://github.com/veecle/tricore-probe --version 0.2.1
 ```
 
 ### Attribution
@@ -84,9 +84,13 @@ INFO  LED2 toggle
 
 For more sample code refer to the Bluewind [bare-metal examples](https://github.com/bluewind-embedded-systems/bw-r-drivers-tc37x-examples) and to the Veecle [PXROS examples](https://github.com/veecle/veecle-pxros/tree/main/examples).
 
-For applications running on multiple cores you can specify the number of active cores in the application with a flag on the CLI (by default 1):
+For applications not running on all the available cores, you can specify the number of active cores in the application with a CLI flag in order to prevent abrupt exit from the `rtt` session (by default, all of the cores available to the MCU are used):
 ```
 > tricore-probe --cores <n> app.elf 
+```
+Note that this parameter only works for applications running on contiguous cores. For example, on a tri-core processor, with an application only starting `core0` and `core2`, this session will stop anyway:
+```
+> tricore-probe --cores 2 app.elf 
 ```
 
 ## Cargo runner

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker build . --tag veecle/flash-tricore --build-arg=AGREE_INFINEON_TERMS=1 -f 
 
 Install `tricore-probe`:
 ```shell
-cargo install tricore-probe --git https://github.com/veecle/tricore-probe --version 0.2.0
+cargo install --path .
 ```
 
 ### Attribution
@@ -67,7 +67,7 @@ The Linux setup is based on a modified version of the [`wineftd2xx` project](htt
 ## Quickstart
 
 ```
-> tricore-probe <your-executable>.elf --list-devices
+> tricore-probe --list-devices
 Found 1 devices:
 Device 0: "DAS JDS AURIX LITE KIT V2.0 (TC375) LK7KFCF1"
 ```
@@ -84,9 +84,14 @@ INFO  LED2 toggle
 
 For more sample code refer to the Bluewind [bare-metal examples](https://github.com/bluewind-embedded-systems/bw-r-drivers-tc37x-examples) and to the Veecle [PXROS examples](https://github.com/veecle/veecle-pxros/tree/main/examples).
 
+For applications running on multiple cores you can specify the number of active cores in the application with a flag on the CLI (by default 1):
+```
+> tricore-probe --cores <n> app.elf 
+```
+
 ## Cargo runner
 This program can be configured as a [runner](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner).
-Check [`main.rs`](src/main.rs) for additional configuration options.
+Check [`main.rs`](src/main.rs) or run `tricore-probe --help` for additional configuration options.
 
 A simple runner config for a TC375 lite kit could look like this:
 

--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -115,7 +115,7 @@ impl Write for DefmtDecoder {
 pub fn decode_rtt<W: Write>(
     core: &mut Core<'_>,
     secondary_cores: &mut [Core<'_>],
-    active_cores: u8,
+    active_cores: usize,
     rtt_block_address: u64,
     mut data_sink: W,
 ) -> anyhow::Result<HaltReason> {
@@ -245,16 +245,14 @@ pub fn decode_rtt<W: Write>(
             return exit_reason.context("Cannot query state of the main core");
         }
 
-        for (secondary_index, core) in secondary_cores.iter_mut().enumerate() {
-            log::debug!("Secondary core index: {}, active cores: {}", secondary_index, active_cores);
-            // eww
-            let active_secondary_cores = (active_cores - 1).into();
-            let secondary_core_id = secondary_index + 1;
-            if secondary_core_id > active_secondary_cores {
-                // Core is not active so ignore it and all the next ones
-                log::debug!("Breaking away");
-                break;
-            }
+        let secondary_active_cores = active_cores - 1;
+
+        // Only check for exit on active cores
+        for (secondary_index, core) in secondary_cores
+            .iter_mut()
+            .take(secondary_active_cores)
+            .enumerate()
+        {
             if let Some(exit_reason) = should_exit_for_core(core, true) {
                 if exit_reason.is_ok() {
                     // FIXME: The core index we give here might be misleading, we can probably obtain

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ struct Args {
 
     /// Path to the binary.
     #[arg(value_parser = existing_path)]
-    elf: PathBuf,
+    elf: Option<PathBuf>,
+
+    /// Number of active cores in application
+    #[arg(short, long, default_value_t = 1)]
+    cores: u8,
 
     /// Configures the log level.
     #[arg(short, long, value_enum, required = false, default_value_t = LogLevel::Warn)]
@@ -71,8 +75,8 @@ fn main() -> anyhow::Result<()> {
         let command = docker_command
             .stderr(Stdio::inherit())
             .stdout(Stdio::inherit())
-            // "-t" is required for color output.
-            .args(["run", "--init", "--rm", "-t"]);
+            // "-t" is required for color output. -i to forward termination to the container
+            .args(["run", "--init", "--rm", "-t", "-i"]);
 
         let mut tricore_args = Vec::new();
         if args.no_flash {
@@ -87,6 +91,9 @@ fn main() -> anyhow::Result<()> {
             tricore_args.push(device.clone());
         }
 
+        tricore_args.push("--cores".to_owned());
+        tricore_args.push(args.cores.to_string());
+
         match args.log_level {
             LogLevel::Warn => tricore_args.push("--log-level=warn".to_owned()),
             LogLevel::Info => tricore_args.push("--log-level=info".to_owned()),
@@ -94,41 +101,46 @@ fn main() -> anyhow::Result<()> {
             LogLevel::Trace => tricore_args.push("--log-level=trace".to_owned()),
         };
 
-        let temp_dir = if let Ok(absolute_path) = args.elf.canonicalize() {
-            let elf_content = fs::read(&absolute_path)
-                .context("Cannot load elf file")
-                .unwrap();
-            let ihex_content = elf_to_hex(&elf_content)
-                .context("Cannot convert elf to hex file")
-                .unwrap();
-            let temporary_directory =
-                TempDir::new().context("Failed to set up temporary directory")?;
-            let ihex_path = temporary_directory.path().join("output.hex");
-            fs::write(&ihex_path, ihex_content)
-                .context("Cannot create temporary hex file")
-                .unwrap();
+        let temp_dir = match args.elf {
+            Some(path) => {
+                if let Ok(absolute_path) = path.canonicalize() {
+                    let elf_content = fs::read(&absolute_path)
+                        .context("Cannot load elf file")
+                        .unwrap();
+                    let ihex_content = elf_to_hex(&elf_content)
+                        .context("Cannot convert elf to hex file")
+                        .unwrap();
+                    let temporary_directory =
+                        TempDir::new().context("Failed to set up temporary directory")?;
+                    let ihex_path = temporary_directory.path().join("output.hex");
+                    fs::write(&ihex_path, ihex_content)
+                        .context("Cannot create temporary hex file")
+                        .unwrap();
 
-            let elf_path_mount = format!(
-                "{}:{}",
-                ihex_path.as_path().to_str().unwrap(),
-                "/root/.wine/drive_c/output.hex"
-            );
-            println!("-v {}", elf_path_mount);
-            command.arg("-v").arg(elf_path_mount);
+                    let elf_path_mount = format!(
+                        "{}:{}",
+                        ihex_path.as_path().to_str().unwrap(),
+                        "/root/.wine/drive_c/output.hex"
+                    );
+                    println!("-v {}", elf_path_mount);
+                    command.arg("-v").arg(elf_path_mount);
 
-            let filename = absolute_path.file_name().unwrap().to_str().unwrap();
-            let file_path_in_docker_in_wine = format!("/root/.wine/drive_c/{}", filename);
-            let elf_path_mount = format!(
-                "{}:{}",
-                absolute_path.as_path().to_str().unwrap(),
-                file_path_in_docker_in_wine
-            );
-            println!("-v {}", elf_path_mount);
-            command.arg("-v").arg(elf_path_mount);
-            tricore_args.push(format!("C:\\{}", filename));
-            temporary_directory
-        } else {
-            bail!("File not working for some reason.");
+                    let filename = absolute_path.file_name().unwrap().to_str().unwrap();
+                    let file_path_in_docker_in_wine = format!("/root/.wine/drive_c/{}", filename);
+                    let elf_path_mount = format!(
+                        "{}:{}",
+                        absolute_path.as_path().to_str().unwrap(),
+                        file_path_in_docker_in_wine
+                    );
+                    println!("-v {}", elf_path_mount);
+                    command.arg("-v").arg(elf_path_mount);
+                    tricore_args.push(format!("C:\\{}", filename));
+                    Some(temporary_directory)
+                } else {
+                    None
+                }
+            }
+            None => None,
         };
 
         let mut daemon_command = "RUST_LOG=trace xvfb-run wine64 tricore-probe.exe".to_owned();
@@ -176,7 +188,7 @@ fn main() -> anyhow::Result<()> {
         use colored::Colorize;
         use defmt::DefmtDecoder;
 
-        let mut command_server = ChipCommunication::new()?;
+        let mut command_server = ChipCommunication::new(args.cores)?;
 
         if args.list_devices {
             let scanned_devices = command_server.list_devices()?;
@@ -206,25 +218,32 @@ fn main() -> anyhow::Result<()> {
             command_server.connect(None)?;
         }
 
-        if !args.no_flash {
-            command_server
-                .flash_elf(args.elf.as_path())
-                .context("Cannot flash elf file")?;
-        } else {
-            log::warn!("Flashing skipped - this might lead to malformed defmt data!")
+        if let Some(elf) = args.elf {
+            log::debug!("Elf file is {}", elf.display());
+            if args.no_flash  {
+                log::warn!("Flashing skipped - this might lead to malformed defmt data!")
+            }
+            else {
+                command_server
+                    .flash_elf(elf.as_path())
+                    .context("Cannot flash elf file")?;
+            }
+
+            let mut defmt_decoder = DefmtDecoder::spawn(elf.as_path())?;
+
+            let backtrace = command_server.read_rtt(
+                defmt_decoder.rtt_control_block_address(),
+                &mut defmt_decoder,
+            )?;
+
+            let backtrace_info = backtrace.addr2line(elf.as_path())?;
+
+            println!("{}", "Device halted, backtrace as follows".red());
+            backtrace_info.log_stdout();
         }
-
-        let mut defmt_decoder = DefmtDecoder::spawn(args.elf.as_path())?;
-
-        let backtrace = command_server.read_rtt(
-            defmt_decoder.rtt_control_block_address(),
-            &mut defmt_decoder,
-        )?;
-
-        let backtrace_info = backtrace.addr2line(args.elf.as_path())?;
-
-        println!("{}", "Device halted, backtrace as follows".red());
-        backtrace_info.log_stdout();
+        else {
+            log::warn!("Nothing to do here without elf")
+        }
     }
     Ok(()) as Result<(), anyhow::Error>
 }


### PR DESCRIPTION
This PR includes support for not specifying the .elf file on operations that don't require it (eg. `--list-devices`) and for limiting the number of cores checked for session termination.
In this way it is possible to see `defmt` messages on single (or dual) core applications without the session terminating abruptly.

The flag `--cores` has been added to the CLI in order to specify the number of active cores.

NOTE: It was necessary to revert to v1.0.10 of `AURIXFlasher` and to version `8.0.5`, otherwise the board was not being recognised (Shieldbuddy TC375)

resolves #36, resolves #11 


