### PR TITLE
Update to AURIX flasher 3.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ tricore-docker/artifacts
 target
 Cargo.lock
 .idea
-tricore-docker/DAS_V8_0_5_SETUP.exe
+tricore-docker/DAS_*_SETUP.exe
+tricore-docker/AURIXFlasherSoftwareTool-setup_*.exe
 tricore-docker/aurixflashersoftwaretool_1.0.10_Windows_x64.msi
-tricore-docker/DAS_V8_1_4_SETUP.exe
-tricore-docker/AURIXFlasherSoftwareTool-setup_3.0.0_20241030-1737.exe

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ To use this setup, make sure you checked the terms and conditions of these progr
 docker build . --tag veecle/flash-tricore --build-arg=AGREE_INFINEON_TERMS=1 -f tricore-docker/Dockerfile
 ```
 
-Install `tricore-probe`:
+Install `tricore-probe` from the current directory.
 ```shell
-cargo install tricore-probe --git https://github.com/veecle/tricore-probe
+cargo install tricore-probe --path .
 ```
 
 ### Attribution

--- a/tricore-docker/Dockerfile
+++ b/tricore-docker/Dockerfile
@@ -73,7 +73,8 @@ ENV CFLAGS_x86_64_pc_windows_msvc="$CL_FLAGS" \
 RUN rustup target add x86_64-pc-windows-msvc
 
 # Use cargo-chef to enable caching of dependencies.
-RUN cargo install cargo-chef --locked
+# Note that versions after 0.1.68 require newer Rust toolchain than 1.74.0.
+RUN cargo install cargo-chef@0.1.68 --locked
 
 WORKDIR /cargo-bin
 
@@ -108,10 +109,10 @@ RUN apt-get update
 RUN apt-get install --no-install-recommends -y innoextract
 WORKDIR "/root"
 # Copy Aurix flasher setup.
-COPY ["tricore-docker/AURIXFlasherSoftwareTool-setup_3.0.0_20241030-1737.exe", "."]
+COPY ["tricore-docker/AURIXFlasherSoftwareTool-setup_3.0.2_20241218-1439.exe", "."]
 # Extract Aurix flasher.
 # This will extract to pwd/app.
-RUN innoextract AURIXFlasherSoftwareTool-setup_3.0.0_20241030-1737.exe
+RUN innoextract AURIXFlasherSoftwareTool-setup_3.0.2_20241218-1439.exe
 
 FROM ubuntu:jammy AS runner
 
@@ -185,5 +186,3 @@ ENV DAS_HOME="C:\\DAS64"
 ENV AURIX_FLASHER_PATH="C:\\Infineon\\AURIXFlasherSoftwareTool\\AURIXFlasher.exe"
 
 CMD ["bash"]
-
-

--- a/tricore-docker/Dockerfile
+++ b/tricore-docker/Dockerfile
@@ -2,7 +2,7 @@
 
 # Use the official rust image with xwin (https://github.com/Jake-Shadle/xwin) as base.
 #
-FROM docker.io/library/rust:1.74.0-slim-bookworm AS builder-base
+FROM docker.io/library/rust:1.85.0-slim-bookworm AS builder-base
 
 ENV KEYRINGS /usr/local/share/keyrings
 
@@ -73,8 +73,7 @@ ENV CFLAGS_x86_64_pc_windows_msvc="$CL_FLAGS" \
 RUN rustup target add x86_64-pc-windows-msvc
 
 # Use cargo-chef to enable caching of dependencies.
-# Note that versions after 0.1.68 require newer Rust toolchain than 1.74.0.
-RUN cargo install cargo-chef@0.1.68 --locked
+RUN cargo install cargo-chef@0.1.71 --locked
 
 WORKDIR /cargo-bin
 


### PR DESCRIPTION
* Bump to the latest AURIX flasher available
* Update docker image to use rust 1.85 (latest at the moment) because sub-sub dependencies were failing on 1.74
~* Lock the version of `cargo-chef@0.1.68` because newer versions use newer Rust toolchain (in theory it should also be updated, but that might be more distabilizing - better do it separatelly)~
* fix cargo-chef to the current version to ensure more stable docker image builds
* Minor space linting